### PR TITLE
翻译的一点修改: _logger修改为logger

### DIFF
--- a/public/docs/ts/latest/guide/dependency-injection.jade
+++ b/public/docs/ts/latest/guide/dependency-injection.jade
@@ -603,7 +603,7 @@ block ctor-syntax
   The constructor now asks for an injected instance of a `Logger` and stores it in a private property called `#{_priv}logger`.
   We call that property within our `getHeroes` method when anyone asks for heroes.
 
-  现在，这个构造函数会要求一个`Logger`类的实例注入进来，并且把它存到一个名为`_logger`的私有属性中。
+  现在，这个构造函数会要求一个`Logger`类的实例注入进来，并且把它存到一个名为`logger`的私有属性中。
   当别人要求获得英雄数据时，我们会在`getHeroes`方法中使用这个属性。
 
 //- FIXME refer to Dart API when that page becomes available.


### PR DESCRIPTION
因为英文原文中那个私有变量是`logger`所以我觉得还是用`logger`比较好。