### PR TITLE
AppModule 在 app.module.ts内 原文也错了

### DIFF
--- a/public/docs/ts/latest/glossary.jade
+++ b/public/docs/ts/latest/glossary.jade
@@ -58,9 +58,9 @@ block includes
       帮助我们将一个应用程序组织成拼合的功能模块群。一个Angular模块标识了被应用程序使用的组件、指令和管道等，它同时包含了应用程序需要的外来Angular模块的列表，比如`FormsModule`。
   
       Every Angular application has an application root module class. By convention the class is
-      called `AppModule` and resides in a file named `app.component.ts`.
+      called `AppModule` and resides in a file named `app.module.ts`.
   
-      每个Angular应用程序都有一个应用程序根模块类。按规约这个类的名字为`AppModule`，存放在名为`app.component.ts`的文件。
+      每个Angular应用程序都有一个应用程序根模块类。按规约这个类的名字为`AppModule`，存放在名为`app.module.ts`的文件。
   
       For details and examples, see the [Angular Module](!{docsLatest}/guide/ngmodule.html) page.
   


### PR DESCRIPTION
每个 Angular 应用程序都有一个应用程序根模块类。按规约这个类的名字为 AppModule ，存放在名为 app.component.ts 的文件。
->
每个 Angular 应用程序都有一个应用程序根模块类。按规约这个类的名字为 AppModule ，存放在名为 app.module.ts 的文件。