### PR TITLE
Aio

### DIFF
--- a/aio/content/examples/attribute-directives/src/app/app.component.1.html
+++ b/aio/content/examples/attribute-directives/src/app/app.component.1.html
@@ -1,14 +1,14 @@
 <!-- #docregion -->
 <h1>My First Attribute Directive</h1>
 <!-- #docregion applied -->
-<p appHightlight>Highlight me!</p>
+<p myHighlight>Highlight me!</p>
 <!-- #enddocregion applied,  -->
 
 <!-- #docregion color-1 -->
-<p appHightlight highlightColor="yellow">Highlighted in yellow</p>
-<p appHightlight [highlightColor]="'orange'">Highlighted in orange</p>
+<p myHighlight highlightColor="yellow">Highlighted in yellow</p>
+<p myHighlight [highlightColor]="'orange'">Highlighted in orange</p>
 <!-- #enddocregion color-1 -->
 
 <!-- #docregion color-2 -->
-<p appHightlight [highlightColor]="color">Highlighted with parent component's color</p>
+<p myHighlight [highlightColor]="color">Highlighted with parent component's color</p>
 <!-- #enddocregion color-2 -->

--- a/aio/content/examples/attribute-directives/src/app/app.component.html
+++ b/aio/content/examples/attribute-directives/src/app/app.component.html
@@ -8,11 +8,11 @@
   <input type="radio" name="colors" (click)="color='cyan'">Cyan
 </div>
 <!-- #docregion color -->
-<p [appHighlight]="color">Highlight me!</p>
+<p [myHighlight]="color">Highlight me!</p>
 <!-- #enddocregion color, v2 -->
 
 <!-- #docregion defaultColor -->
-<p [appHighlight]="color" defaultColor="violet">
+<p [myHighlight]="color" defaultColor="violet">
   Highlight me too!
 </p>
 <!-- #enddocregion defaultColor, -->
@@ -20,5 +20,5 @@
 <hr>
 <p><i>Mouse over the following lines to see fixed highlights</i></p>
 
-<p [appHighlight]="'yellow'">Highlighted in yellow</p>
-<p appHighlight="orange">Highlighted in orange</p>
+<p [myHighlight]="'yellow'">Highlighted in yellow</p>
+<p myHighlight="orange">Highlighted in orange</p>

--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.1.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.1.ts
@@ -2,7 +2,7 @@
 // #docregion
 import { Directive, ElementRef, Input } from '@angular/core';
 
-@Directive({ selector: '[appHighlight]' })
+@Directive({ selector: '[myHighlight]' })
 export class HighlightDirective {
     constructor(el: ElementRef) {
        el.nativeElement.style.backgroundColor = 'yellow';

--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.2.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.2.ts
@@ -4,7 +4,7 @@
 import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 
 @Directive({
-  selector: '[appHighlight]'
+  selector: '[myHighlight]'
 })
 export class HighlightDirective {
   // #docregion ctor

--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.3.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.3.ts
@@ -3,13 +3,13 @@
 import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 
 @Directive({
-  selector: '[appHighlight]'
+  selector: '[myHighlight]'
 })
 export class HighlightDirective {
 
   constructor(private el: ElementRef) { }
 
-  @Input('appHighlight') highlightColor: string;
+  @Input('myHighlight') highlightColor: string;
 
   // #docregion mouse-enter
   @HostListener('mouseenter') onMouseEnter() {

--- a/aio/content/examples/attribute-directives/src/app/highlight.directive.ts
+++ b/aio/content/examples/attribute-directives/src/app/highlight.directive.ts
@@ -4,7 +4,7 @@ import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 // #enddocregion imports
 
 @Directive({
-  selector: '[appHighlight]'
+  selector: '[myHighlight]'
 })
 export class HighlightDirective {
 
@@ -15,7 +15,7 @@ export class HighlightDirective {
   // #enddocregion defaultColor
 
   // #docregion color
-  @Input('appHighlight') highlightColor: string;
+  @Input('myHighlight') highlightColor: string;
   // #enddocregion color
 
   // #docregion mouse-enter

--- a/aio/content/examples/dependency-injection-in-action/src/app/highlight.directive.ts
+++ b/aio/content/examples/dependency-injection-in-action/src/app/highlight.directive.ts
@@ -3,11 +3,11 @@
 import { Directive, ElementRef, HostListener, Input } from '@angular/core';
 
 @Directive({
-  selector: '[appHighlight]'
+  selector: '[myHighlight]'
 })
 export class HighlightDirective {
 
-  @Input('appHighlight') highlightColor: string;
+  @Input('myHighlight') highlightColor: string;
 
   private el: HTMLElement;
 

--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -1001,7 +1001,7 @@ clear the container which also destroys the view.
 
 Nobody reads the `myUnless` property so it doesn't need a getter.
 
-没有人会读取`myUnless`属性，因此它不需要定义设置器（getter）。
+没有人会读取`myUnless`属性，因此它不需要定义getter。
 
 The completed directive code looks like this:
 


### PR DESCRIPTION
* 原文将getter定义为设置器，是否不合理？建议不用翻译
* [属性型指令](https://angular.cn/guide/attribute-directives) 样例的指令名混乱 
