### PR TITLE
修改依赖注入章节的某处翻译错误

### DIFF
--- a/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
+++ b/public/docs/ts/latest/guide/hierarchical-dependency-injection.jade
@@ -118,7 +118,7 @@ figure.image-display
   If you only specify providers at the top level (typically the root `AppModule`), the tree of injectors appears to be flat.
   All requests bubble up to the root <code>NgModule</code> injector that you configured with the `bootstrapModule` method.
   
-  如果我们只在顶级（通常是根模块`AppModule`），这三个注入器看起来将是“平面”的。
+  如果我们只在顶级（通常是根模块`AppModule`），注入器树看起来将是“平面”的。
   所有的申请都会冒泡到根<code>NgModule</code>进行处理，也就是我们在`bootstrapModule`方法中配置的那个。
 
 .l-main-section


### PR DESCRIPTION
https://angular.cn/guide/dependency-injection-in-action

'tree' is not 'three', so ‘这三个注入器’ should be ‘输入器树’