### PR TITLE
修改指令选择器的值错误

### DIFF
--- a/aio/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
+++ b/aio/content/examples/form-validation/src/app/shared/forbidden-name.directive.ts
@@ -14,7 +14,7 @@ export function forbiddenNameValidator(nameRe: RegExp): ValidatorFn {
 
 // #docregion directive
 @Directive({
-  selector: '[appForbiddenName]',
+  selector: '[forbiddenName]',
   // #docregion directive-providers
   providers: [{provide: NG_VALIDATORS, useExisting: ForbiddenValidatorDirective, multi: true}]
   // #enddocregion directive-providers


### PR DESCRIPTION
修改`selector: '[forbiddenName]',`指令选择器值与组件模板中的指令不一致的错误。