### PR TITLE
修改翻译错误

### DIFF
--- a/aio/content/guide/reactive-forms.md
+++ b/aio/content/guide/reactive-forms.md
@@ -399,7 +399,7 @@ This guide uses four fundamental classes to build a reactive form:
 
       Class
 
-      CSS 类
+      类
 
     </th>
 


### PR DESCRIPTION
应该显示响应式表单的基础类，而不是CSS类。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
