### PR TITLE
fix: 修正翻译的一个语义错误

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -1921,8 +1921,8 @@ and routing configuration, including `RouterModule.forRoot`, into this routing m
 Re-export the Angular `RouterModule` by adding it to the module `exports` array.
 By re-exporting the `RouterModule` here the components declared in `AppModule` will have access to router directives such as `RouterLink` and `RouterOutlet`.
 
-把它添加到该模块的 `exports` 数组中，以再次导出 `RouterModule`。
-通过在 `AppModule` 中导入 `AppRoutingModule` 并再次导出 `RouterModule`，那些声明在 `AppModule` 中的组件就可以访问路由指令了，比如 `RouterLink` 和 `RouterOutlet`。
+把`RouterModule`添加到该模块的 `exports` 数组中，以再次导出它 。
+通过再次导出`RouterModule`，当在 `AppModule` 中导入了 `AppRoutingModule`之后，那些声明在 `AppModule` 中的组件就可以访问路由指令了，比如 `RouterLink` 和 `RouterOutlet`。
 
 After these steps, the file should look like this.
 


### PR DESCRIPTION
> 通过在 `AppModule` 中导入 `AppRoutingModule` 并再次导出 `RouterModule`，那些声明在 `AppModule` 中的组件就可以访问路由指令了，比如 `RouterLink` 和 `RouterOutlet`。

这句翻译很容易造成一些理解上的困难和错误，因为`AppModule`并不需要也不会再次导出`RouterModule`，事实上，`AppModule`不会导出任何模块。
我想它本来想表达的意思是
>  通过在`AppRoutingModule` 再次导出 `RouterModule`，然后在 `AppModule` 中导入 `AppRoutingModule`，那些声明在 `AppModule` 中的组件就可以访问路由指令了，比如 `RouterLink` 和 `RouterOutlet`。

所以我做了一些修改，避免原来的语句表述造成的歧义。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
