### PR TITLE
fix typo

### DIFF
--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -43,7 +43,7 @@ Angular 的最佳实践之一就是在一个独立的顶级模块中加载和配
 
 By convention, the module class name is `AppRoutingModule` and it belongs in the `app-routing.module.ts` in the `src/app` folder.
 
-按照惯例，这个模块类的名字叫做 `APPRoutingModule`，并且位于 `src/app` 下的 `app-routing.module.ts` 文件中。
+按照惯例，这个模块类的名字叫做 `AppRoutingModule`，并且位于 `src/app` 下的 `app-routing.module.ts` 文件中。
 
 Use the CLI to generate it.
 


### PR DESCRIPTION
修复错误，原文为`AppRoutingModule`

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
