### PR TITLE
fix: 修复路由与导航章节中的一个锚点跳转地址错误

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -5218,7 +5218,7 @@ In the [route parameters](#optional-route-parameters) example, you only dealt wi
 the route, but what if you wanted optional parameters available to all routes?
 This is where query parameters come into play.
 
-在这个[查询参数](guide/router#query-parameters)例子中，你只为路由指定了参数，但是该如何定义一些所有路由中都可用的可选参数呢？
+在这个[查询参数](#optional-route-parameters)例子中，你只为路由指定了参数，但是该如何定义一些所有路由中都可用的可选参数呢？
 这就该“查询参数”登场了。
 
 [Fragments](https://en.wikipedia.org/wiki/Fragment_identifier) refer to certain elements on the page


### PR DESCRIPTION
翻译后的文字附带的锚点点击无效，对照英文翻译的锚点对其进行了修正。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
