### PR TITLE
修复路由与导航章节中查询参数和段落段落翻译的一些疏漏

### DIFF
--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -5248,7 +5248,7 @@ second argument in the `router.navigate` function
 and provide the `queryParamsHandling` and `preserveFragment` to pass along the current query parameters
 and fragment to the next route.
 
-还可以再导航之间**保留**查询参数和片段，而无需再次再导航中提供。在 `LoginComponent` 中的 `router.navigate` 方法中，添加第二个参数，该**对象**提供了 `preserveQueryParams` 和 `preserveFragment`，用于传递到当前的查询参数中并为下一个路由提供片段。
+还可以再导航之间**保留**查询参数和片段，而无需再次再导航中提供。在 `LoginComponent` 中的 `router.navigate` 方法中，添加第二个参数，该**对象**提供了 `queryParamsHandling` 和 `preserveFragment`，用于传递到当前的查询参数中并为下一个路由提供片段。
 
 <code-example path="router/src/app/auth/login/login.component.ts" linenums="false" header="src/app/auth/login/login.component.ts (preserve)" region="preserve">
 
@@ -5297,7 +5297,7 @@ authentication tokens or session ids.
 The `query params` and `fragment` can also be preserved using a `RouterLink` with
 the `queryParamsHandling` and `preserveFragment` bindings respectively.
 
-“查询参数”和“片段”也可以分别用 `RouterLink` 中的 **preserveQueryParams** 和 **preserveFragment** 保存。
+“查询参数”和“片段”也可以分别用 `RouterLink` 中的 **queryParamsHandling** 和 **preserveFragment** 保存。
 
 </div>
 

--- a/aio/content/guide/router.md
+++ b/aio/content/guide/router.md
@@ -5248,7 +5248,7 @@ second argument in the `router.navigate` function
 and provide the `queryParamsHandling` and `preserveFragment` to pass along the current query parameters
 and fragment to the next route.
 
-还可以再导航之间**保留**查询参数和片段，而无需再次再导航中提供。在 `LoginComponent` 中的 `router.navigate` 方法中，添加第二个参数，该**对象**提供了 `queryParamsHandling` 和 `preserveFragment`，用于传递到当前的查询参数中并为下一个路由提供片段。
+还可以在导航之间**保留**查询参数和片段，而无需再次在导航中提供。在 `LoginComponent` 中的 `router.navigate` 方法中，添加一个对象作为第二个参数，该**对象**提供了 `queryParamsHandling` 和 `preserveFragment`，用于传递当前的查询参数和片段到下一个路由。
 
 <code-example path="router/src/app/auth/login/login.component.ts" linenums="false" header="src/app/auth/login/login.component.ts (preserve)" region="preserve">
 


### PR DESCRIPTION
+ 修正了两个错别字(两处`在`字错写成了`再`）
+ 修正了一个属性错误(`preserveQueryParams`在 *4.0* 之后已被`queryParamsHandling`取代，此处英文文档中也是`queryParamsHandling`,应该是翻译疏漏)
+ 修改了段落中的一句翻译，使其更通顺和易懂。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
