### PR TITLE
docs(forms): 修复错别字

### DIFF
--- a/packages/forms/src/validators.ts
+++ b/packages/forms/src/validators.ts
@@ -77,7 +77,7 @@ const EMAIL_REGEXP =
  * A validator is a function that processes a `FormControl` or collection of
  * controls and returns an error map or null. A null map means that validation has passed.
  *
- * 验证器就是一个函数，它可以处理单个 `FormControl` 好一组控件，并返回一个错误映射表（map）或 null。null 表示验证已通过了。
+ * 验证器就是一个函数，它可以处理单个 `FormControl` 或一组控件，并返回一个错误映射表（map）或 null。null 表示验证已通过了。
  *
  * @see [Form Validation](/guide/form-validation)
  *


### PR DESCRIPTION
原译文：
验证器就是一个函数，它可以处理单个 `FormControl` 好一组控件，
修改后：
验证器就是一个函数，它可以处理单个 `FormControl` 或一组控件，

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
