### PR TITLE
docs: line 260,“属性”改为“properties”

### DIFF
--- a/aio/content/guide/schematics-for-libraries.md
+++ b/aio/content/guide/schematics-for-libraries.md
@@ -258,7 +258,7 @@ When you add a schematic to the collection, you have to point to it in the colle
 
 * *properties* : An object that defines the available options for the schematic.
 
-  *属性*：一个定义该原理图可用选项的对象。
+  *properties*：一个定义该原理图可用选项的对象。
 
 
   Each option associates key with a type, description, and optional alias.


### PR DESCRIPTION
根据上下文，此处properties指的是schema.json的properties属性，故不需要翻译成中文。跟上文的id,title,type一样，不需要翻译

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
