### PR TITLE
docs: 翻译错误修正

### DIFF
--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -549,7 +549,7 @@ You'll refer to the `<ng-template>` when you [write your own structural directiv
 
 ## The *&lt;ng-template&gt;*
 
-## *&lt;ng-template&gt;元素*
+## *&lt;ng-template&gt;*元素
 
 The &lt;ng-template&gt; is an Angular element for rendering HTML.
 It is never displayed directly.

--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -549,7 +549,7 @@ You'll refer to the `<ng-template>` when you [write your own structural directiv
 
 ## The *&lt;ng-template&gt;*
 
-## *&lt;ng-template&gt;*
+## *&lt;ng-template&gt;元素*
 
 The &lt;ng-template&gt; is an Angular element for rendering HTML.
 It is never displayed directly.

--- a/aio/content/guide/structural-directives.md
+++ b/aio/content/guide/structural-directives.md
@@ -549,7 +549,7 @@ You'll refer to the `<ng-template>` when you [write your own structural directiv
 
 ## The *&lt;ng-template&gt;*
 
-## *&lt;ng-template&gt;*指令
+## *&lt;ng-template&gt;*
 
 The &lt;ng-template&gt; is an Angular element for rendering HTML.
 It is never displayed directly.


### PR DESCRIPTION
ng-template不是指令

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
