### PR TITLE
docs: 文档翻译改进

### DIFF
--- a/aio/content/guide/rx-library.md
+++ b/aio/content/guide/rx-library.md
@@ -66,7 +66,7 @@ You can use _pipes_ to link operators together. Pipes let you combine multiple f
 
 A set of operators applied to an observable is a recipe&mdash;that is, a set of instructions for producing the values you’re interested in. By itself, the recipe doesn’t do anything. You need to call `subscribe()` to produce a result through the recipe.
 
-应用于某个可观察对象上的一组操作符就像一个菜谱 —— 也就是说，对你感兴趣的这些值进行处理的一组操作步骤。这个菜谱本身不会做任何事。你需要调用 `subscribe()` 来通过这个菜谱生成一个结果。
+应用于某个可观察对象上的一组操作符就像一个处理流程 —— 也就是说，对你感兴趣的这些值进行处理的一组操作步骤。这个处理流程本身不会做任何事。你需要调用 `subscribe()` 来通过处理流程得出并生成一个结果。
 
 Here’s an example:
 


### PR DESCRIPTION
生搬硬套的英文翻译并不是很好，我觉得再英文原有的意思之上使用更加中文化的翻译会更好一些

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
