### PR TITLE
docs: 文档关于9.0 ts版本描述错误

### DIFF
--- a/aio/content/guide/updating-to-version-9.md
+++ b/aio/content/guide/updating-to-version-9.md
@@ -57,7 +57,7 @@ See our [template type-checking guide](guide/template-typecheck) for more inform
 
 - Typescript 3.4 and 3.5 are no longer supported. Please update to Typescript 3.7.
 
-  不再支持 TypeScript 3.4 和 3.5。请更新至 Typescript 3.6。
+  不再支持 TypeScript 3.4 和 3.5。请更新至 Typescript 3.7。
 
 
 - `tslib` is now listed as a peer dependency rather than a direct dependency. If you are not using the CLI, you must manually install `tslib`, using `yarn add tslib` or `npm install tslib --save`.


### PR DESCRIPTION
ts版本描述更改为3。7

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
