### PR TITLE
"it" 并非指 "product" 属性

### DIFF
--- a/aio/content/start/routing.md
+++ b/aio/content/start/routing.md
@@ -118,7 +118,7 @@ The product details component handles the display of each product. The Angular R
 
    1. Define the `product` property and inject the `ActivatedRoute` into the constructor by adding it as an argument within the constructor's parentheses.
 
-      定义 `product` 属性，并把它加入构造函数括号中作为参数，以便把 `ActivatedRoute` 注入到构造函数中。
+      定义 `product` 属性，并将路由作为参数添加到构造函数的括号中，以便把 `ActivatedRoute` 注入到构造函数中。
 
       <code-example header="src/app/product-details/product-details.component.ts" path="getting-started/src/app/product-details/product-details.component.1.ts" region="props-methods">
       </code-example>


### PR DESCRIPTION
原文：`Define the product property and inject the ActivatedRoute into the constructor by adding it as an argument within the constructor's parentheses.`
如果翻译为：”定义 product 属性，并把它加入构造函数括号中作为参数，以便把 ActivatedRoute 注入到构造函数中。“，则语意上是把 product 属性加入构造函数。实际不是，实际是把 `route` 加入构造函数中。
原文中的 `it` 不是指代 `product`，而是指代路由对象。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
