### PR TITLE
传递当前的查询参数和片段到下一个路由

### DIFF
--- a/aio/content/examples/router/src/app/auth/login/login.component.ts
+++ b/aio/content/examples/router/src/app/auth/login/login.component.ts
@@ -28,7 +28,7 @@ export class LoginComponent {
       if (this.authService.isLoggedIn) {
         // Get the redirect URL from our auth service
         // If no redirect has been set, use the default
-        let redirect = this.authService.redirectUrl ? this.router.parseUrl(this.authService.redirectUrl) : '/admin';
+        const redirect = this.authService.redirectUrl || '/admin';
 
         // #docregion preserve
         // Set our navigation extras object
@@ -39,7 +39,7 @@ export class LoginComponent {
         };
 
         // Redirect the user
-        this.router.navigateByUrl(redirect, navigationExtras);
+        this.router.navigate([redirect], navigationExtras);
         // #enddocregion preserve
       }
     });


### PR DESCRIPTION
测试发现：使用navigateByUrl不能传递当前的查询参数和片段到下一个路由，可能是因为该函数不会对当前 URL 做任何修改。总之，使用this.router.navigate则可正确传递以上信息。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
