### PR TITLE
docs: 翻译修正

### DIFF
--- a/aio/content/guide/hierarchical-dependency-injection.md
+++ b/aio/content/guide/hierarchical-dependency-injection.md
@@ -25,7 +25,7 @@ in this hierarchy using an `@NgModule()` or `@Injectable()` annotation.
 
    `ModuleInjector` 层次结构 —— 使用 `@NgModule()` 或 `@Injectable()` 注解在此层次结构中配置 `ModuleInjector`。
 
-1. `ElementInjector` hierarchy&mdash;created implicitly at each
+2. `ElementInjector` hierarchy&mdash;created implicitly at each
 DOM element. An `ElementInjector` is empty by default
 unless you configure it in the `providers` property on
 `@Directive()` or `@Component()`.
@@ -309,7 +309,7 @@ resolves it in two phases:
 
    针对 `ElementInjector` 层次结构（其父级）
 
-1. Against the `ModuleInjector` hierarchy (its parents)
+2. Against the `ModuleInjector` hierarchy (its parents)
 
    针对 `ModuleInjector` 层次结构（其父级）
 


### PR DESCRIPTION
#479 ，好像删除空行并没有两个行进入同一序列。之前的 #480 没有起到效果。我删掉了同一序列中两个空行的一行。顺便手工将序号修正。

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
