### PR TITLE
docs: Angular Component 概述 —— 声明组件的样式 段落中单词错误

### DIFF
--- a/aio/content/guide/component-overview.md
+++ b/aio/content/guide/component-overview.md
@@ -269,7 +269,7 @@ You can declare component styles uses for its template in one of two ways: by re
 
 To declare the styles for a component in a separate file, add a `stylesUrls` property to the `@Component` decorator.
 
-要在单独的文件中声明组件的样式，就要把 `stylesUrls` 属性添加到 `@Component` 装饰器中。
+要在单独的文件中声明组件的样式，就要把 `styleUrls` 属性添加到 `@Component` 装饰器中。
 
 <code-example
     path="component-overview/src/app/component-overview/component-overview.component.ts"

--- a/aio/content/guide/component-overview.md
+++ b/aio/content/guide/component-overview.md
@@ -267,7 +267,7 @@ You can declare component styles uses for its template in one of two ways: by re
 
 你有以下两种方式来为组件的模板声明样式：引用一个外部文件，或直接写在组件内部。
 
-To declare the styles for a component in a separate file, add a `stylesUrls` property to the `@Component` decorator.
+To declare the styles for a component in a separate file, add a `styleUrls` property to the `@Component` decorator.
 
 要在单独的文件中声明组件的样式，就要把 `styleUrls` 属性添加到 `@Component` 装饰器中。
 


### PR DESCRIPTION
> 要在单独的文件中声明组件的样式，就要把 `stylesUrls` 属性添加到 `@Component` 装饰器中。

`stylesUrls` 应该为 `styleUrls`

注意：

1. 新版本的文档位于aio分支下，master分支下是老版本的文档。
2. 原则上不再接受对老版本的PR。
