### PR TITLE
docs: 改变数字类型从`+`更改为官网最新使用的`Number()`

### DIFF
--- a/aio/content/examples/toh-pt5/src/app/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/toh-pt5/src/app/hero-detail/hero-detail.component.ts
@@ -34,7 +34,7 @@ export class HeroDetailComponent implements OnInit {
 
   // #docregion getHero
   getHero(): void {
-    const id = +this.route.snapshot.paramMap.get('id');
+    const id = Number(this.route.snapshot.paramMap.get('id'));
     this.heroService.getHero(id)
       .subscribe(hero => this.hero = hero);
   }

--- a/aio/content/examples/toh-pt6/src/app/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/toh-pt6/src/app/hero-detail/hero-detail.component.ts
@@ -24,7 +24,7 @@ export class HeroDetailComponent implements OnInit {
   }
 
   getHero(): void {
-    const id = +this.route.snapshot.paramMap.get('id');
+    const id = Number(this.route.snapshot.paramMap.get('id'));
     this.heroService.getHero(id)
       .subscribe(hero => this.hero = hero);
   }

--- a/aio/content/examples/universal/src/app/hero-detail/hero-detail.component.ts
+++ b/aio/content/examples/universal/src/app/hero-detail/hero-detail.component.ts
@@ -24,7 +24,7 @@ export class HeroDetailComponent implements OnInit {
   }
 
   getHero(): void {
-    const id = +this.route.snapshot.paramMap.get('id');
+    const id = Number(this.route.snapshot.paramMap.get('id'));
     this.heroService.getHero(id)
       .subscribe(hero => this.hero = hero);
   }

--- a/aio/content/tutorial/toh-pt5.md
+++ b/aio/content/tutorial/toh-pt5.md
@@ -677,11 +677,11 @@ The `"id"` key returns the `id` of the hero to fetch.
 `"id"` 对应的值就是要获取的英雄的 `id`。
 
 Route parameters are always strings.
-The JavaScript (+) operator converts the string to a number,
-which is what a hero `id` should be.
+The JavaScript Number function converts the string to a number,
+which is what a hero id should be.
 
 路由参数总会是字符串。
-JavaScript 的 (+) 操作符会把字符串转换成数字，英雄的 `id` 就是数字类型。
+JavaScript 的 `Number` 函数会把字符串转换成数字，英雄的 `id` 应当是数字类型。
 
 The browser refreshes and the app crashes with a compiler error.
 `HeroService` doesn't have a `getHero()` method.


### PR DESCRIPTION
最新官网文档（版本: stable v11.2.10）使用`Number()`
实测用`+`在vscode中会引起ts报错
链接： https://angular.io/tutorial/toh-pt5